### PR TITLE
Template subcharts first by default

### DIFF
--- a/pkg/shalm/chart_template.go
+++ b/pkg/shalm/chart_template.go
@@ -48,7 +48,7 @@ type capabilities struct {
 }
 
 func (c *chartImpl) Template(thread *starlark.Thread) Stream {
-	streams := []Stream{c.template(thread, "", false)}
+	streams := []Stream{}
 	err := c.eachSubChart(func(subChart *chartImpl) error {
 		streams = append(streams, subChart.template(thread, "", false))
 		return nil
@@ -56,6 +56,7 @@ func (c *chartImpl) Template(thread *starlark.Thread) Stream {
 	if err != nil {
 		return ErrorStream(err)
 	}
+	streams = append(streams, c.template(thread, "", false))
 	return yamlConcat(streams...)
 }
 


### PR DESCRIPTION
IMO, we subcharts are more commonly used as a precondition for your actual chart.
If we template subcharts first, we will hopefully directly notice if they fail. Otherwise we only notice errors in subcharts once we consume them via their methods.