### PR TITLE
Fix how api-paths are generated from GVK

### DIFF
--- a/pkg/shalm/k8s_client.go
+++ b/pkg/shalm/k8s_client.go
@@ -43,9 +43,6 @@ func init() {
 	sort.Slice(kinds, func(i, j int) bool { return kinds[i].Version > kinds[j].Version })
 	for _, k := range kinds {
 		groupVersion := schema.GroupVersionKind{Version: k.Version, Group: k.Group, Kind: strings.ToLower(k.Kind) + "s"}
-		if len(groupVersion.Group) == 0 {
-			groupVersion.Group = "api"
-		}
 		kindToGroupVersionKind[strings.ToLower(k.Kind)] = groupVersion
 		kindToGroupVersionKind[strings.ToLower(k.Kind)+"."+groupVersion.Group] = groupVersion
 		kindToGroupVersionKind[groupVersion.Kind] = groupVersion
@@ -106,10 +103,18 @@ func (r request) Do() result {
 	if !ok {
 		return result{err: errUnknownResource}
 	}
-	if r.namespace != nil {
-		r.request.AbsPath(gv.Group, gv.Version, "namespaces", *r.namespace, gv.Kind, r.name)
+
+	prefix := ""
+	if len(gv.Group) == 0 {
+		prefix = "api"
 	} else {
-		r.request.AbsPath(gv.Group, gv.Version, gv.Kind, r.name)
+		prefix = "apis"
+	}
+
+	if r.namespace != nil {
+		r.request.AbsPath(prefix, gv.Group, gv.Version, "namespaces", *r.namespace, gv.Kind, r.name)
+	} else {
+		r.request.AbsPath(prefix, gv.Group, gv.Version, gv.Kind, r.name)
 	}
 	return result{Result: r.request.Do()}
 }

--- a/pkg/shalm/k8s_client_test.go
+++ b/pkg/shalm/k8s_client_test.go
@@ -28,4 +28,26 @@ var _ = Describe("k8s client", func() {
 		Expect(obj.Kind).To(Equal("Service"))
 	})
 
+	It("can read kubernetes deployment", func() {
+		// NOTICE: deployment is not in the core k8s api group
+		config, err := configKube("")
+		if err != nil {
+			Skip("no connection to k8s")
+		}
+		client, err := newK8sClient(config)
+		if err != nil {
+			Skip("no connection to k8s")
+		}
+		namespace := "kube-system"
+		obj, err := client.Get().
+			Namespace(&namespace).
+			Resource("deployments").
+			Name("metrics-server").
+			Do().
+			Get()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(obj.Kind).To(Equal("Deployment"))
+	})
+
 })


### PR DESCRIPTION
When using resources other then k8s-core resources (e.g. deployments) the path is prefixed with `/apis/`, this was not done by shalm.
